### PR TITLE
Fix Depart also removing channel from c.channels map

### DIFF
--- a/client.go
+++ b/client.go
@@ -113,7 +113,11 @@ func (c *Client) Join(channel string) {
 
 // Depart leave a twitch channel
 func (c *Client) Depart(channel string) {
-	c.send(fmt.Sprintf("PART #%s", channel))
+	if c.connActive.get() {
+		go c.send(fmt.Sprintf("PART #%s", channel))
+	}
+
+	delete(c.channels, channel)
 }
 
 // Disconnect close current connection

--- a/client_test.go
+++ b/client_test.go
@@ -773,6 +773,10 @@ func TestCanDepartChannel(t *testing.T) {
 	client.IrcAddress = ":4331"
 	go client.Connect()
 
+	// wait for the connection to go active
+	for !client.connActive.get() {
+		time.Sleep(time.Millisecond * 2)
+	}
 	client.Depart("gempir")
 
 	// wait for server to receive message
@@ -783,6 +787,90 @@ func TestCanDepartChannel(t *testing.T) {
 	}
 
 	assertStringsEqual(t, "PART #gempir", receivedMsg)
+}
+
+func TestDepartNegatesJoinIfNotConnected(t *testing.T) {
+	wait := make(chan struct{})
+
+	waitEnd := make(chan struct{})
+	var partMessageReceived bool
+	var joinMessageReceived bool
+
+	go func() {
+		cer, err := tls.LoadX509KeyPair("test_resources/server.crt", "test_resources/server.key")
+		if err != nil {
+			log.Println(err)
+			return
+		}
+		config := &tls.Config{
+			Certificates: []tls.Certificate{cer},
+		}
+		ln, err := tls.Listen("tcp", ":4332", config)
+		if err != nil {
+			t.Fatal(err)
+		}
+		close(wait)
+		conn, err := ln.Accept()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer ln.Close()
+		defer conn.Close()
+
+		reader := bufio.NewReader(conn)
+		tp := textproto.NewReader(reader)
+
+		for {
+			message, err := tp.ReadLine()
+			if err != nil && err != io.EOF {
+				t.Fatal(err)
+			}
+			message = strings.Replace(message, "\r\n", "", 1)
+			if strings.HasPrefix(message, "NICK") {
+				fmt.Fprintf(conn, ":tmi.twitch.tv 001 justinfan123123 :Welcome, GLHF!\r\n")
+			}
+			if strings.HasPrefix(message, "PART") {
+				partMessageReceived = true
+				close(waitEnd)
+			}
+			if strings.HasPrefix(message, "JOIN") {
+				joinMessageReceived = true
+				close(waitEnd)
+			}
+		}
+	}()
+
+	// wait for server to start
+	select {
+	case <-wait:
+	case <-time.After(time.Second * 3):
+		t.Fatal("testserver didn't start")
+	}
+
+	client := NewClient("justinfan123123", "oauth:123123132")
+	client.IrcAddress = ":4332"
+
+	client.Join("gempir")
+	client.Depart("gempir")
+
+	go client.Connect()
+
+	// wait for the connection to go active
+	for !client.connActive.get() {
+		time.Sleep(time.Millisecond * 2)
+	}
+
+	// wait for server to receive message
+	select {
+	case <-waitEnd:
+	case <-time.After(time.Second * 1):
+		if partMessageReceived {
+			t.Fatal("erroneously received part message")
+		}
+		if joinMessageReceived {
+			t.Fatal("erroneously received join message")
+		}
+	}
 }
 
 func TestCanPong(t *testing.T) {


### PR DESCRIPTION
This stops the "automatic rejoin on reconnect" from joining a channel the bot has already departed from